### PR TITLE
Call SoftLaunchSignIn rather than redirecting to the vc2-sl page.

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -39,7 +39,7 @@ func IndexHandler(c *gin.Context) {
 			return
 		}
 
-		c.Redirect(http.StatusFound, "/vc2-sl")
+		SoftLaunchSignIn(c);
 		return
 	}
 


### PR DESCRIPTION
I noticed that when visiting the index page while logged in I was getting a redirect to /vc2-sl every time. I took a look at the IndexHandler function and thought, what if we just call SoftLaunchSignIn instead of doing a redirect? It seems to work. Only downside I as far as I can tell is the session gets loaded twice but compared to a redirect that seems not so bad.